### PR TITLE
Recommend but not impose overcommit

### DIFF
--- a/rails/rails.md
+++ b/rails/rails.md
@@ -23,7 +23,7 @@
 * Mantener actualizados a la última versión estable ruby y rails.
 * A no ser que un gem indique lo contrario, utilizar [pesimistic semantic versioning](https://robots.thoughtbot.com/rubys-pessimistic-operator), mandando actualizar a la última versión que no rompe la API, a la hora de especificar las dependencias en el Gemfile. E.g.: `~> 2.1`
 * Periódicamente, actualizar el Gemfile.
-* Seguir las recomendaciones de seguridad de engines cómo bundler-audit o brakeman de overcommit (ver más abajo).
+* Seguir las recomendaciones de seguridad de engines cómo bundler-audit o brakeman.
 * Para aplicaciones bajo el dominio `herokuapp.com`, utilizar https con HSTS. Para otros casos, dependerá de lo acordado con el cliente.
 
 ## Consumo de memoria y performance
@@ -42,6 +42,6 @@
 
 ## Calidad y estándares de código
 
-Se trabajará con [overcommit](https://github.com/brigade/overcommit) para asegurar una calidad en el código y seguir unos estándares que permitan un mejor mantenimiento y crecimiento de la aplicación. Por defecto seguiremos la configuración inicial de cada engine, pero, por consenso, podemos adaptarlo.
+Se recomienda trabajar con [overcommit](https://github.com/brigade/overcommit) para asegurar una calidad en el código y seguir unos estándares que permitan un mejor mantenimiento y crecimiento de la aplicación.
 
-La configuración a utilizar la encontramos en el [.overcommit.yml](.overcommit.yml) de este mismo directorio.
+Una configuración recomendada a utilizar la encontramos en el [.overcommit.yml](.overcommit.yml) de este mismo directorio.


### PR DESCRIPTION
Como hablamos, introduzco estos cambios en las guías para recomendar overcommit en lugar de exigirlo durante el development. Como dijimos, no tenemos capacidad ni tiempo para imponerlo, mientras que preferimos confiar en los criterios del programador y establecer controles desde nuestra parte mediante, por ejemplo, codeclimate.