### PR TITLE
Do not force `staging` and `production` branches

### DIFF
--- a/git.md
+++ b/git.md
@@ -4,11 +4,7 @@
 
 * La rama de entorno de desarrollo es `master`. Sin embargo, no es un "work in progress". El desarrollo real se realiza en "feature branchs", cuyos cambios se pasan a master una vez finalizada la funcionalidad.
 
-* La rama `staging` contiene la versión que actualmente puede consultar el cliente en su entorno de pruebas.
-
-* La rama `production` contiene la versión que actualmente está en producción.
-
-* Para casos en que es necesario un "hotfix", realizar el cambio directamente en la rama `staging` o `production` (según sea el caso) e incorporar inmediatamente los cambios a `master`. Las ramas `staging` y `production` no se utilizan para nada más que esto.
+* Para casos en que es necesario un "hotfix", realizar el cambio directamente en la revisiones correspondientes a los entornos `staging` o `production` (según sea el caso) e incorporar inmediatamente los cambios a `master`.
 
 * Siempre que sea posible, integrar los cambios upstream con `git pull --rebase` para mantener una historia lineal de cambios.
 


### PR DESCRIPTION
Hasta ahora, para realizar hotfixs, se recomendaba disponer de ramas locales `staging` y `production` que fueran en línea con los entornos `staging` y `production`. Esto no tenía mucho sentido, ya que se puede hacer un hotfix de otras formas igual de válidas, como crear dettached HEAD a partir de la rev actual del entorno en cuestión.

No recomendar esas ramas es aún más importante al estar utilizando las pipelines de heroku, pues al hacer un promote el repositorio remoto no se actualiza (sinó que sólo cambia el slug precompilado de la aplicación).